### PR TITLE
Added RemoveDefaultRequestHeader

### DIFF
--- a/src/MyTested.WebApi.Tests/BuildersTests/ServersTests/ServerTestBuilderTests.cs
+++ b/src/MyTested.WebApi.Tests/BuildersTests/ServersTests/ServerTestBuilderTests.cs
@@ -355,6 +355,33 @@ namespace MyTested.WebApi.Tests.BuildersTests.ServersTests
                 .WithStatusCode(HttpStatusCode.OK);
         }
 
+        [Test]
+        public void RemoveDefaultHeadersAfterAddShouldWorkCorrectly()
+        {
+            MyWebApi
+                .Server()
+                .Working<CustomStartup>()
+                .WithDefaultRequestHeader("CustomHeader", "CustomValue")
+                .RemoveDefaultRequestHeader("Customheader")
+                .WithHttpRequestMessage(req => req.WithMethod(HttpMethod.Get))
+                .ShouldReturnHttpResponseMessage()
+                .WithStatusCode(HttpStatusCode.NotFound)
+                .WithStringContent("Header not found!");
+        }
+
+        [Test]
+        public void RemoveDefaultHeadersNonExistingDoesNotThrowException()
+        {
+            MyWebApi
+                .Server()
+                .Working<CustomStartup>()
+                .RemoveDefaultRequestHeader("Customheader")
+                .WithHttpRequestMessage(req => req.WithMethod(HttpMethod.Get))
+                .ShouldReturnHttpResponseMessage()
+                .WithStatusCode(HttpStatusCode.NotFound)
+                .WithStringContent("Header not found!");
+        }
+
         [TestFixtureTearDown]
         public void RestoreConfiguration()
         {

--- a/src/MyTested.WebApi.Tests/BuildersTests/ServersTests/ServerTestBuilderTests.cs
+++ b/src/MyTested.WebApi.Tests/BuildersTests/ServersTests/ServerTestBuilderTests.cs
@@ -362,7 +362,7 @@ namespace MyTested.WebApi.Tests.BuildersTests.ServersTests
                 .Server()
                 .Working<CustomStartup>()
                 .WithDefaultRequestHeader("CustomHeader", "CustomValue")
-                .RemoveDefaultRequestHeader("Customheader")
+                .WithoutDefaultRequestHeader("Customheader")
                 .WithHttpRequestMessage(req => req.WithMethod(HttpMethod.Get))
                 .ShouldReturnHttpResponseMessage()
                 .WithStatusCode(HttpStatusCode.NotFound)
@@ -375,7 +375,7 @@ namespace MyTested.WebApi.Tests.BuildersTests.ServersTests
             MyWebApi
                 .Server()
                 .Working<CustomStartup>()
-                .RemoveDefaultRequestHeader("Customheader")
+                .WithoutDefaultRequestHeader("Customheader")
                 .WithHttpRequestMessage(req => req.WithMethod(HttpMethod.Get))
                 .ShouldReturnHttpResponseMessage()
                 .WithStatusCode(HttpStatusCode.NotFound)

--- a/src/MyTested.WebApi.Tests/Setups/CustomStartup.cs
+++ b/src/MyTested.WebApi.Tests/Setups/CustomStartup.cs
@@ -42,6 +42,12 @@ namespace MyTested.WebApi.Tests.Setups
                     return context.Response.WriteAsync("OK!");
                 }
 
+                if (!context.Request.Headers.ContainsKey("CustomHeader"))
+                {
+                    context.Response.StatusCode = 404;
+                    return context.Response.WriteAsync("Header not found!");
+                }
+
                 context.Response.StatusCode = 404;
                 return context.Response.WriteAsync("Not found!");
             });

--- a/src/MyTested.WebApi/Builders/Servers/ServerTestBuilder.cs
+++ b/src/MyTested.WebApi/Builders/Servers/ServerTestBuilder.cs
@@ -82,10 +82,18 @@ namespace MyTested.WebApi.Builders.Servers
             return this;
         }
 
-        public IServerBuilder RemoveDefaultRequestHeader(string name)
+        /// <summary>
+        /// Removes a previously added default header from every request tested on the server.
+        /// </summary>
+        /// <param name="name">Name of the header.</param>
+        /// <returns></returns>
+        public IServerBuilder WithoutDefaultRequestHeader(string name)
         {
             if (client.DefaultRequestHeaders.Contains(name))
+            {
                 client.DefaultRequestHeaders.Remove(name);
+            }
+
             return this;
         }
 

--- a/src/MyTested.WebApi/Builders/Servers/ServerTestBuilder.cs
+++ b/src/MyTested.WebApi/Builders/Servers/ServerTestBuilder.cs
@@ -82,6 +82,13 @@ namespace MyTested.WebApi.Builders.Servers
             return this;
         }
 
+        public IServerBuilder RemoveDefaultRequestHeader(string name)
+        {
+            if (client.DefaultRequestHeaders.Contains(name))
+                client.DefaultRequestHeaders.Remove(name);
+            return this;
+        }
+
         /// <summary>
         /// Adds HTTP request message to the tested server.
         /// </summary>

--- a/src/MyTested.WebApi/IServerBuilder.cs
+++ b/src/MyTested.WebApi/IServerBuilder.cs
@@ -43,7 +43,7 @@ namespace MyTested.WebApi
         /// </summary>
         /// <param name="name">Name of the header.</param>
         /// <returns></returns>
-        IServerBuilder RemoveDefaultRequestHeader(string name);
+        IServerBuilder WithoutDefaultRequestHeader(string name);
 
         /// <summary>
         /// Adds HTTP request message to the tested server.

--- a/src/MyTested.WebApi/IServerBuilder.cs
+++ b/src/MyTested.WebApi/IServerBuilder.cs
@@ -39,6 +39,13 @@ namespace MyTested.WebApi
         IServerBuilder WithDefaultRequestHeaders(IDictionary<string, IEnumerable<string>> headers);
 
         /// <summary>
+        /// Removes a previously added default header from every request tested on the server.
+        /// </summary>
+        /// <param name="name">Name of the header.</param>
+        /// <returns></returns>
+        IServerBuilder RemoveDefaultRequestHeader(string name);
+
+        /// <summary>
         /// Adds HTTP request message to the tested server.
         /// </summary>
         /// <param name="requestMessage">Instance of HttpRequestMessage.</param>


### PR DESCRIPTION
When using WithDefaultRequestHeader (or any of the overloads) to set default headers for all your integration tests, you sometimes wished you didn't have headers for one particular test. RemoveDefaultRequestHeader enables this scenario.

Also enables replacing default headers like "Authentication" which can't be set twice. Replacing an existing key in the WithDefaultRequestHeader call might not always be wanted, as some headers can be set multiple times.